### PR TITLE
fix: change Owner's name definition to string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,7 @@ declare module 'podparse' {
     }
 
     export interface Owner {
-        name: Author;
+        name: string;
         email: string;
     }
 


### PR DESCRIPTION
Hi 👋

I noticed that it looks like the type definition here is not right.

Thanks for work on this module!