### PR TITLE
Update/fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,8 @@ declare module 'podparse' {
         summary: string;
         type: string;
 
+        generator?: string;
+
         category?: string[];
         keywords?: string[];
 
@@ -109,14 +111,14 @@ declare module 'podparse' {
         url: string;
         type?: string;
         length?: number;
-        title?: string;
         duration?: number;
     }
 
     export interface Person {
         name: string;
         role: string;
-        group?: string;
+        group: string;
+        img?: string;
         href?: string;
     }
 
@@ -128,6 +130,8 @@ declare module 'podparse' {
     export interface Transcript {
         url: string;
         type: string;
+        language?: string;
+        rel?: string;
     }
 
     export interface Chapter {


### PR DESCRIPTION
The PR includes some updates/fixes to the type declarations

- `generator` is missing
- `enclosure` doesn't have a title attribute
- For `Person`:
  - `group` gets a[ default value](https://github.com/Tombarr/podcast-feed-parser/blob/b31a91f2c747141ba4809bb678c4857a65d2cd5c/index.js#L459) in the same way as `role` so I removed the optionality
  - `img` is parsed but it's missing in the definition
- `language` and `rel` are missing from the definition of `Transcript`